### PR TITLE
Allow for eslint config overrides in workspaces

### DIFF
--- a/packages/brite-cli/package.json
+++ b/packages/brite-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eventbrite/brite-cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A CLI around building Eventbrite applications.",
   "main": "dist/brite.js",
   "bin": {
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@eventbrite/brite-core": "^0.0.1",
+    "@eventbrite/brite-core": "^0.0.2",
     "react-addons-test-utils": "^15.6.2"
   },
   "devDependencies": {

--- a/packages/brite-core/package.json
+++ b/packages/brite-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eventbrite/brite-core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A CLI around building Eventbrite applications.",
   "main": "dist/index.js",
   "keywords": [],

--- a/packages/brite-core/src/tasks/eslint/defaults.ts
+++ b/packages/brite-core/src/tasks/eslint/defaults.ts
@@ -1,6 +1,5 @@
 export default {
     parser: 'babel-eslint',
-    useEslintrc: false,
     cache: true,
     baseConfig: {
         env: {

--- a/packages/simple-app-demo/package.json
+++ b/packages/simple-app-demo/package.json
@@ -11,6 +11,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@eventbrite/brite-cli": "0.0.1"
+    "@eventbrite/brite-cli": "0.0.2"
   }
 }


### PR DESCRIPTION
This may have just been a one off, but in the babel plugin I wrote I needed to throw in a top level config to be able to make lint pass. 

Not sure if we want to allow this for everyone, but it opening this seems like a much small jump off the ledge than each workspace having to configure and use eslint separately. 