### PR TITLE
Add library build flag to webpack build project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Brite CLI
-A CLI of plugins to run tasks such as linting, testing, etc, and presets to wrap up the plugins into reusable patterns.
+Brite-CLI is a command line tool of plugins to run tasks such as linting, testing, etc, and presets to wrap up the plugins into reusable patterns.
 
 ### Packages
 * Brite-CLI

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Brite CLI
-Brite-CLI is a command line tool of plugins to run tasks such as linting, testing, etc, and presets to wrap up the plugins into reusable patterns.
+Brite-CLI is a collection of commands and configurations that create a simple and consistent developer experience within the Eventbrite ecosystem.
 
 ### Packages
 * Brite-CLI

--- a/packages/brite-cli/package.json
+++ b/packages/brite-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eventbrite/brite-cli",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A CLI around building Eventbrite applications.",
   "main": "dist/brite.js",
   "bin": {
@@ -13,7 +13,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@eventbrite/brite-core": "^0.0.2",
+    "@eventbrite/brite-core": "^0.0.3",
     "react-addons-test-utils": "^15.6.2"
   },
   "devDependencies": {

--- a/packages/brite-core/package.json
+++ b/packages/brite-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eventbrite/brite-core",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A CLI around building Eventbrite applications.",
   "main": "dist/index.js",
   "keywords": [],

--- a/packages/brite-core/src/plugins/brite-cli-plugin-webpack/webpack.config.web.ts
+++ b/packages/brite-core/src/plugins/brite-cli-plugin-webpack/webpack.config.web.ts
@@ -87,7 +87,7 @@ export default ({
     port = DEFAULT_PORT,
     outputPath,
     basePath,
-    passThroughArgs,
+    passThroughArgs = [],
 }: IBriteCommandOptions) => ({
     target: WEB_TARGET,
     bail: !DEV_ENV,

--- a/packages/brite-core/src/plugins/brite-cli-plugin-webpack/webpack.config.web.ts
+++ b/packages/brite-core/src/plugins/brite-cli-plugin-webpack/webpack.config.web.ts
@@ -87,6 +87,7 @@ export default ({
     port = DEFAULT_PORT,
     outputPath,
     basePath,
+    passThroughArgs,
 }: IBriteCommandOptions) => ({
     target: WEB_TARGET,
     bail: !DEV_ENV,
@@ -100,14 +101,14 @@ export default ({
             assertFileExists(path.resolve(cwd, basePath, 'index.js')),
         ],
     },
-    externals: [
+    externals: passThroughArgs.indexOf('--library') > - 1 ? [
         nodeExternals({
             modulesDir: path.resolve(cwd, 'node_modules'),
         }),
         nodeExternals({
             modulesDir: path.resolve(cwd, '../../node_modules'),
         }),
-    ],
+    ] : [],
     output: {
         path: outputPath || path.resolve(cwd, 'build'),
         filename: `[name].${WEB_TARGET}.js`,

--- a/packages/simple-app-demo/package.json
+++ b/packages/simple-app-demo/package.json
@@ -11,6 +11,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@eventbrite/brite-cli": "0.0.2"
+    "@eventbrite/brite-cli": "*"
   }
 }


### PR DESCRIPTION
This got left off the open source migration. Causing require errors when working locally. 