### PR TITLE
fix typo in start command which is setting a wrong value in NODE_ENV var

### DIFF
--- a/packages/brite-core/src/commands/start.ts
+++ b/packages/brite-core/src/commands/start.ts
@@ -5,7 +5,7 @@ import { BaseBriteCommand, BriteCommandResult } from './command';
  * Run webpack, all kinds of fun start things
  */
 export default class BriteStartCommand extends BaseBriteCommand {
-    public defaultEnvironment = 'develpment';
+    public defaultEnvironment = 'development';
 
     /**
      * Executes the start command


### PR DESCRIPTION
there is a typo in `start` command which is setting `process.env.NODE_ENV` to `develpment` which is causing some things not properly work on dev env